### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/quantinuum-dev/qulacs-worker/releases/tag/v0.1.0) - 2025-04-17
+
+### Added
+
+- Initial working implementation
+
+### Fixed
+
+- Switch to fasteval and anyhow
+
+### Other
+
+- Correct release branch
+- Update deps and README
+- Add CI and release steps
+- Fix deps specfication
+- Initial commit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,23 +507,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "qulacs-worker"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "bitvec",
- "fasteval",
- "insta",
- "num",
- "qulacs-bridge",
- "rand",
- "rstest",
- "serde",
- "serde_json",
- "tket-json-rs",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,6 +773,23 @@ dependencies = [
  "serde_json",
  "strum",
  "uuid",
+]
+
+[[package]]
+name = "tkr_qulacs_worker"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bitvec",
+ "fasteval",
+ "insta",
+ "num",
+ "qulacs-bridge",
+ "rand",
+ "rstest",
+ "serde",
+ "serde_json",
+ "tket-json-rs",
 ]
 
 [[package]]


### PR DESCRIPTION



## 🤖 New release

* `tkr_qulacs_worker`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/quantinuum-dev/qulacs-worker/releases/tag/v0.1.0) - 2025-04-17

### Added

- Initial working implementation

### Fixed

- Switch to fasteval and anyhow

### Other

- Correct release branch
- Update deps and README
- Add CI and release steps
- Fix deps specfication
- Initial commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).