### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/quantinuum-dev/tkr_qulacs_worker/compare/v0.1.0...v0.1.1) - 2025-04-28
+
+### Added
+
+- Allow n_shots to be specified
+
 ## [0.1.0](https://github.com/quantinuum-dev/tkr_qulacs_worker/releases/tag/v0.1.0) - 2025-04-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "tkr_qulacs_worker"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tkr_qulacs_worker"
 description = "Tierkreis Worker for running Qulacs simulations"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 keywords = ["quantum", "simulator", "qulacs", "tierkreis"]


### PR DESCRIPTION



## 🤖 New release

* `tkr_qulacs_worker`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/quantinuum-dev/tkr_qulacs_worker/compare/v0.1.0...v0.1.1) - 2025-04-28

### Added

- Allow n_shots to be specified
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).